### PR TITLE
Add setSnooze & endSnooze

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ I have created a lot of different Arduino libraries that I hope people can make 
 | ------------- |-------------|
 | setPresence      | users:write |
 | setCustomStatus      | users.profile:write |
+| dnd.setSnooze | dnd.write |
+| dnd.endSnooze | dnd.write |
 
 - scroll up to the top of the page and click "install app to workspace"
 - Click "Allow" on the next page

--- a/src/ArduinoSlack.cpp
+++ b/src/ArduinoSlack.cpp
@@ -166,6 +166,22 @@ SlackProfile ArduinoSlack::setCustomStatus(const char *text, const char *emoji, 
     return profile;
 }
 
+bool ArduinoSlack::setSnooze(int numMinutes)
+{
+    char command[200];
+    sprintf(command, SLACK_DND_SET_SNOOZE_ENDPOINT, _bearerToken, numMinutes);
+    SLACK_DEBUG_SERIAL_LN(command);
+
+    const size_t bufferSize = 1000;
+    return simpleHandler(makeGetRequest(command, ""), bufferSize);
+}
+
+bool ArduinoSlack::endSnooze()
+{
+    const size_t bufferSize = 1000;
+    return simpleHandler(makePostRequest(SLACK_DND_END_SNOOZE_ENDPOINT, ""), bufferSize);
+}
+
 bool ArduinoSlack::simpleHandler(int response, const size_t bufferSize)
 {
     bool okStatus = false;

--- a/src/ArduinoSlack.h
+++ b/src/ArduinoSlack.h
@@ -60,6 +60,7 @@ public:
   ArduinoSlack(Client &client, const char *bearerToken);
 
   int makePostRequest(const char *command, const char *body, const char *contentType = "application/json");
+  int makeGetRequest(const char *command, const char *body, const char *contentType = "application/x-www-form-urlencoded");
   SlackProfile setCustomStatus(const char *text, const char *emoji, int expiration = 0);
   bool setPresence(const char *presence);
   int portNumber = 443;

--- a/src/ArduinoSlack.h
+++ b/src/ArduinoSlack.h
@@ -68,6 +68,7 @@ public:
 
 private:
   const char *_bearerToken;
+  bool simpleHandler(int response, const size_t bufferSize);
   int getHttpStatusCode();
   void skipHeaders(bool tossUnexpectedForJSON = true);
   void closeClient();

--- a/src/ArduinoSlack.h
+++ b/src/ArduinoSlack.h
@@ -45,6 +45,9 @@ MIT License
 #define SLACK_USERS_PROFILE_SET_ENDPOINT "/api/users.profile.set"
 #define SLACK_USERS_SET_PRESENCE_ENDPOINT "/api/users.setPresence?presence=%s"
 
+#define SLACK_DND_SET_SNOOZE_ENDPOINT "/api/dnd.setSnooze?token=%s&num_minutes=%d"
+#define SLACK_DND_END_SNOOZE_ENDPOINT "/api/dnd.endSnooze"
+
 struct SlackProfile
 {
   char *displayName;
@@ -63,6 +66,8 @@ public:
   int makeGetRequest(const char *command, const char *body, const char *contentType = "application/x-www-form-urlencoded");
   SlackProfile setCustomStatus(const char *text, const char *emoji, int expiration = 0);
   bool setPresence(const char *presence);
+  bool setSnooze(int numMinutes = 1);
+  bool endSnooze();
   int portNumber = 443;
   int profileBufferSize = 10000;
   Client *client;


### PR DESCRIPTION
This PR adds basic access to the [`dnd.setSnooze`](https://api.slack.com/methods/dnd.setSnooze) (which requires a `GET` method) & [`dnd.endSnooze`](https://api.slack.com/methods/dnd.endSnooze) endpoints. In addition I've tried to reduce code duplicate code for handing simple responses.